### PR TITLE
[warcio_scrape] Don't skip chihiro URL even if valkyrie URL fails

### DIFF
--- a/playstation_store_2020_oct_scrape/warcio_scrape.py
+++ b/playstation_store_2020_oct_scrape/warcio_scrape.py
@@ -91,7 +91,7 @@ def do_warcio_scrape(parsed_args):
 
             iter_discovered_media_list = []
 
-            logger.info("`%s / %s`: url: `%s`", idx, api_entry_list_size, iter_api_entry)
+            logger.info("`%s / %s`: url: `%s`", idx+1, api_entry_list_size, iter_api_entry)
 
 
             logger.debug("-- making valkyrie api request")

--- a/playstation_store_2020_oct_scrape/warcio_scrape.py
+++ b/playstation_store_2020_oct_scrape/warcio_scrape.py
@@ -118,7 +118,6 @@ def do_warcio_scrape(parsed_args):
 
             if not success:
                 logger.error("-- hit `%s` retries when attempting to get URL `%s`, skipping", MAX_RETRIES, iter_api_entry.valkyrie_url)
-                continue
 
             else:
 


### PR DESCRIPTION
Some content IDs are only valid on chihiro ("entitlements"). 
The current behavior of the script is to skip the ID when the valkyrie URL fails, so I made a small modification so that the chihiro link is always attempted regardless of valkyrie.

Also, I noticed that the logger outputs the index number from 0 to (size -1):
`0 / 30000: url: [...]`
`[...]`
`29999/ 30000: url: [...]`
`Done!`

It's purely cosmetic, but I threw in a fix for that, too.